### PR TITLE
Handler[T,R] should be newable/extendable in newer Scala.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,17 @@ libraryDependencies += "net.exoego" %%% "aws-lambda-scalajs-facade-nodejs-v8" % 
 Import and code.
 
 ```scala
-
+import scala.scalajs.js
 import net.exoego.facade.aws_lambda._
 
 object MyFirstLambda extends APIGatewayProxyHandler {
-  override def apply(arg1: APIGatewayEvent, arg2: Context, arg3: Callback[ProxyResult]): Unit | Promise[APIGatewayProxyResult]
-    = ???
+  @js.annotation.JSName("apply")
+  override def apply(event: APIGatewayEvent, context: Context, callback: Callback[ProxyResult]): Unit = ???
+}
+
+object MyFirstAsyncLambda extends AsyncAPIGatewayProxyHandler {
+  @js.annotation.JSName("apply")
+  override def apply(event: APIGatewayEvent, context: Context): js.Promise[APIGatewayProxyResult]  = ???
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,29 @@ object MyFirstAsyncLambda extends AsyncAPIGatewayProxyHandler {
 }
 ```
 
+Below is available list of pre-defined handler traits:
+
+* ALBHandler
+* APIGatewayProxyHandler
+* CloudFormationCustomResourceHandler
+* CloudFrontRequestHandler
+* CloudFrontResponseHandler
+* CodePipelineCloudWatchActionHandler
+* CodePipelineCloudWatchHandler
+* CodePipelineCloudWatchPipelineHandler
+* CodePipelineHandler
+* CognitoUserPoolTriggerHandler
+* CustomAuthorizerHandler
+* DynamoDBStreamHandler
+* FirehoseTransformationHandler
+* KinesisStreamHandler
+* LexHandler
+* ProxyHandler (alias of APIGatewayProxyHandler)
+* S3BatchHandler
+* S3Handler
+* ScheduledHandler
+* SNSHandler
+* SQSHandler
 
 ## License
 

--- a/src/main/scala/net/exoego/facade/aws_lambda/Handler.scala
+++ b/src/main/scala/net/exoego/facade/aws_lambda/Handler.scala
@@ -1,0 +1,27 @@
+package net.exoego.facade.aws_lambda
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSName
+
+/**
+  * Callback-style handler
+  *
+  * @tparam TEvent
+  * @tparam TResult
+  */
+trait Handler[TEvent, TResult] extends js.Object {
+  @JSName("apply")
+  def apply(event: TEvent, context: Context, callback: Callback[TResult]): Unit
+}
+
+/**
+  * Asynchronous-style handler that returns js.Promise.
+  * This can be used Node.js 8 runtime or more
+  *
+  * @tparam TEvent
+  * @tparam TResult
+  */
+trait AsyncHandler[TEvent, TResult] extends js.Object {
+  @JSName("apply")
+  def apply(event: TEvent, context: Context): js.Promise[TResult]
+}

--- a/src/main/scala/net/exoego/facade/aws_lambda/package.scala
+++ b/src/main/scala/net/exoego/facade/aws_lambda/package.scala
@@ -6,10 +6,13 @@ import scala.scalajs.js.|
 package object aws_lambda {
   type ALBCallback = Callback[ALBResult]
   type ALBHandler = Handler[ALBEvent, ALBResult]
+  type AsyncALBHandler = AsyncHandler[ALBEvent, ALBResult]
   type APIGatewayEvent = APIGatewayProxyEvent
   type APIGatewayProxyCallback = Callback[APIGatewayProxyResult]
   type APIGatewayProxyHandler =
     Handler[APIGatewayProxyEvent, APIGatewayProxyResult]
+  type AsyncAPIGatewayProxyHandler =
+    AsyncHandler[APIGatewayProxyEvent, APIGatewayProxyResult]
   type ArtifactLocation = S3ArtifactStore
   type AttributeValue = facade.amazonaws.services.dynamodb.AttributeValue
   type AuthResponse = CustomAuthorizerResult
@@ -19,6 +22,8 @@ package object aws_lambda {
     CloudFormationCustomResourceCreateEvent | CloudFormationCustomResourceUpdateEvent | CloudFormationCustomResourceDeleteEvent
   type CloudFormationCustomResourceHandler =
     Handler[CloudFormationCustomResourceEvent, Unit]
+  type AsyncCloudFormationCustomResourceHandler =
+    AsyncHandler[CloudFormationCustomResourceEvent, Unit]
   type CloudFormationCustomResourceResponse =
     CloudFormationCustomResourceSuccessResponse | CloudFormationCustomResourceFailedResponse
   type CloudFrontHeaders = js.Dictionary[js.Array[js.Any]]
@@ -26,50 +31,71 @@ package object aws_lambda {
   type CloudFrontRequestCallback = Callback[CloudFrontRequestResult]
   type CloudFrontRequestHandler =
     Handler[CloudFrontRequestEvent, CloudFrontRequestResult]
+  type AsyncCloudFrontRequestHandler =
+    AsyncHandler[CloudFrontRequestEvent, CloudFrontRequestResult]
   type CloudFrontRequestResult =
     js.UndefOr[CloudFrontResultResponse | CloudFrontRequest]
   type CloudFrontResponseCallback = Callback[CloudFrontResponseResult]
   type CloudFrontResponseHandler =
     Handler[CloudFrontResponseEvent, CloudFrontResponseResult]
+  type AsyncCloudFrontResponseHandler =
+    AsyncHandler[CloudFrontResponseEvent, CloudFrontResponseResult]
   type CloudFrontResponseResult = js.UndefOr[CloudFrontResultResponse]
   type CloudWatchLogsHandler = Handler[CloudWatchLogsEvent, Unit]
+  type AsyncCloudWatchLogsHandler = AsyncHandler[CloudWatchLogsEvent, Unit]
   type CodePipelineActionCategory = String
   type CodePipelineActionState = String
   type CodePipelineCloudWatchActionHandler =
     Handler[CodePipelineCloudWatchActionEvent, Unit]
+  type AsyncCodePipelineCloudWatchActionHandler =
+    AsyncHandler[CodePipelineCloudWatchActionEvent, Unit]
   type CodePipelineCloudWatchEvent =
     CodePipelineCloudWatchPipelineEvent | CodePipelineCloudWatchStageEvent | CodePipelineCloudWatchActionEvent
   type CodePipelineCloudWatchHandler =
     Handler[CodePipelineCloudWatchEvent, Unit]
+  type AsyncCodePipelineCloudWatchHandler =
+    AsyncHandler[CodePipelineCloudWatchEvent, Unit]
   type CodePipelineCloudWatchPipelineHandler =
     Handler[CodePipelineCloudWatchPipelineEvent, Unit]
+  type AsyncCodePipelineCloudWatchPipelineHandler =
+    AsyncHandler[CodePipelineCloudWatchPipelineEvent, Unit]
   type CodePipelineCloudWatchStageHandler =
     Handler[CodePipelineCloudWatchStageEvent, Unit]
+  type AsyncCodePipelineCloudWatchStageHandler =
+    AsyncHandler[CodePipelineCloudWatchStageEvent, Unit]
   type CodePipelineHandler = Handler[CodePipelineEvent, Unit]
+  type AsyncCodePipelineHandler = AsyncHandler[CodePipelineEvent, Unit]
   type CodePipelineStageState = String
   type CodePipelineState = String
   type CognitoUserPoolEvent = CognitoUserPoolTriggerEvent
   type CognitoUserPoolTriggerHandler =
     Handler[CognitoUserPoolTriggerEvent, js.Any]
+  type AsyncCognitoUserPoolTriggerHandler =
+    AsyncHandler[CognitoUserPoolTriggerEvent, js.Any]
   type ConditionBlock = js.Dictionary[Condition | js.Array[Condition]]
   type Condition = js.Dictionary[String | js.Array[String]]
   type CustomAuthorizerCallback = Callback[CustomAuthorizerResult]
   type CustomAuthorizerHandler =
     Handler[CustomAuthorizerEvent, CustomAuthorizerResult]
+  type AsyncCustomAuthorizerHandler =
+    AsyncHandler[CustomAuthorizerEvent, CustomAuthorizerResult]
   type DynamoDBStreamHandler = Handler[DynamoDBStreamEvent, Unit]
+  type AsyncDynamoDBStreamHandler = AsyncHandler[DynamoDBStreamEvent, Unit]
   type FirehoseRecordTransformationStatus = String
   type FirehoseTransformationCallback = Callback[FirehoseTransformationResult]
   type FirehoseTransformationHandler =
     Handler[FirehoseTransformationEvent, FirehoseTransformationResult]
-  type Handler[TEvent, TResult] =
-    js.Function3[TEvent, Context, Callback[TResult], Unit] | js.Promise[TResult]
+  type AsyncFirehoseTransformationHandler =
+    AsyncHandler[FirehoseTransformationEvent, FirehoseTransformationResult]
   type Headers = js.Dictionary[String]
   type HeadersBDS = js.Dictionary[Boolean | Double | String]
   type KinesisStreamHandler = Handler[KinesisStreamEvent, Unit]
+  type AsyncKinesisStreamHandler = AsyncHandler[KinesisStreamEvent, Unit]
   type LexCallback = Callback[LexResult]
   type LexDialogAction =
     LexDialogActionClose | LexDialogActionElicitIntent | LexDialogActionElicitSlot | LexDialogActionConfirmIntent | LexDialogActionDelegate
   type LexHandler = Handler[LexEvent, LexResult]
+  type AsyncLexHandler = AsyncHandler[LexEvent, LexResult]
   type MultiValueHeaders = js.Dictionary[js.Array[String]]
   type MultiValueHeadersBDS = js.Dictionary[js.Array[Boolean | Double | String]]
   type PrincipalValue =
@@ -79,13 +105,18 @@ package object aws_lambda {
   type ProxyResult = APIGatewayProxyResult
   type S3BatchCallback = Callback[S3BatchResult]
   type S3BatchHandler = Handler[S3BatchEvent, S3BatchResult]
+  type AsyncS3BatchHandler = AsyncHandler[S3BatchEvent, S3BatchResult]
   type S3BatchResultResultCode = String
   type S3CreateEvent = S3Event
   type S3Handler = Handler[S3Event, Unit]
+  type AsyncS3Handler = AsyncHandler[S3Event, Unit]
   type ScheduledHandler = Handler[ScheduledEvent, Unit]
+  type AsyncScheduledHandler = AsyncHandler[ScheduledEvent, Unit]
   type SNSHandler = Handler[SNSEvent, Unit]
+  type AsyncSNSHandler = AsyncHandler[SNSEvent, Unit]
   type SNSMessageAttributes = js.Dictionary[SNSMessageAttribute]
   type SQSHandler = Handler[SQSEvent, Unit]
+  type AsyncSQSHandler = AsyncHandler[SQSEvent, Unit]
   type SQSMessageAttributeDataType = String
   type SQSMessageAttributes = js.Dictionary[SQSMessageAttribute]
   type Statement =


### PR DESCRIPTION
Closes #83 

A Scala.js-defined JS object cannot directly extend a native JS trait in:

* Scala.js 0.6 with `-P:scalajs:sjsDefinedByDefault` option
* Scala.js 1.0

Currently, `Handler` extends `js.Function3`, so users in such setup cannot extend `Handler` or construct (`new Handler {}`).

This PR changes `Handler[TEvent, TResult]` into a Scala.js-defined trait.
Note that `Handler` and `AsyncHandler` is now clearly distinguished.

```scala
trait Handler[TEvent, TResult] extends js.Object {
  @JSName("apply")
  def apply(event: TEvent, context: Context, callback: Callback[TResult]): Unit
}
trait AsyncHandler[TEvent, TResult] extends js.Object {
  @JSName("apply")
  def apply(event: TEvent, context: Context): js.Promise[TResult]
}
```

 so that it is newable/extendable

```scala
import scala.scalajs.js
import net.exoego.facade.aws_lambda._

object MyFirstLambda extends APIGatewayProxyHandler {
  @js.annotation.JSName("apply")
  override def apply(event: APIGatewayEvent, context: Context, callback: Callback[ProxyResult]): Unit = ???
}
object MyFirstAsyncLambda extends AsyncAPIGatewayProxyHandler {
  @js.annotation.JSName("apply")
  override def apply(event: APIGatewayEvent, context: Context): js.Promise[APIGatewayProxyResult]  = ???
}
```