### PR TITLE
Publish for Scala.js 1.0.0, not for 1.0.0-RC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ scala:
 env:
   matrix:
     - SCALAJS_VERSION="0.6.32"
-    - SCALAJS_VERSION="1.0.1"
+    - SCALAJS_VERSION=""
 
 script:
   - sbt fullOptJS

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,5 +2,5 @@
 
 export SCALAJS_VERSION="0.6.32"
 sbt show scalaVersion
-export SCALAJS_VERSION="1.0.0-RC2"
+unset SCALAJS_VERSION
 sbt show scalaVersion


### PR DESCRIPTION
I thought `0.6.0` starts Scala.js 1.0.0 supports, but it was publisshed for Scalajs 1.0.0-RC...
https://github.com/exoego/aws-lambda-scalajs-facade/releases/tag/v0.6.0