### PR TITLE
Add EventBridge support

### DIFF
--- a/src/main/scala-2.12/net/exoego/facade/aws_lambda/cloudwatch_events_scala212.scala
+++ b/src/main/scala-2.12/net/exoego/facade/aws_lambda/cloudwatch_events_scala212.scala
@@ -1,0 +1,30 @@
+package net.exoego.facade.aws_lambda
+
+import scala.scalajs.js
+
+@js.native
+trait ScheduledEvent extends EventBridgeEvent[String, js.Any]
+
+object ScheduledEvent {
+  def apply(
+      account: String,
+      region: String,
+      detail: js.Any,
+      source: String,
+      time: String,
+      id: String,
+      resources: js.Array[String]
+  ): ScheduledEvent = {
+    val _obj$ = js.Dynamic.literal(
+      "account" -> account.asInstanceOf[js.Any],
+      "region" -> region.asInstanceOf[js.Any],
+      "detail" -> detail.asInstanceOf[js.Any],
+      "detail-type" -> "Scheduled Event",
+      "source" -> source.asInstanceOf[js.Any],
+      "time" -> time.asInstanceOf[js.Any],
+      "id" -> id.asInstanceOf[js.Any],
+      "resources" -> resources.asInstanceOf[js.Any]
+    )
+    _obj$.asInstanceOf[ScheduledEvent]
+  }
+}

--- a/src/main/scala-2.13/net/exoego/facade/aws_lambda/cloudwatch_events_scala213.scala
+++ b/src/main/scala-2.13/net/exoego/facade/aws_lambda/cloudwatch_events_scala213.scala
@@ -3,23 +3,13 @@ package net.exoego.facade.aws_lambda
 import scala.scalajs.js
 
 @js.native
-trait ScheduledEvent extends js.Object {
-  var account: String = js.native
-  var region: String = js.native
-  var detail: js.Dictionary[js.Any] = js.native
-  var `detail-type`: String = js.native
-  var source: String = js.native
-  var time: String = js.native
-  var id: String = js.native
-  var resources: js.Array[String] = js.native
-}
+trait ScheduledEvent extends EventBridgeEvent["Scheduled Event", js.Any]
 
 object ScheduledEvent {
   def apply(
       account: String,
       region: String,
       detail: js.Any,
-      `detail-type`: String,
       source: String,
       time: String,
       id: String,
@@ -29,7 +19,7 @@ object ScheduledEvent {
       "account" -> account.asInstanceOf[js.Any],
       "region" -> region.asInstanceOf[js.Any],
       "detail" -> detail.asInstanceOf[js.Any],
-      "detail-type" -> `detail-type`.asInstanceOf[js.Any],
+      "detail-type" -> "Scheduled Event",
       "source" -> source.asInstanceOf[js.Any],
       "time" -> time.asInstanceOf[js.Any],
       "id" -> id.asInstanceOf[js.Any],

--- a/src/main/scala/net/exoego/facade/aws_lambda/eventbridge.scala
+++ b/src/main/scala/net/exoego/facade/aws_lambda/eventbridge.scala
@@ -1,0 +1,41 @@
+package net.exoego.facade.aws_lambda
+import scala.scalajs.js
+
+trait EventBridgeEvent[TDetailType <: String, TDetail] extends js.Object {
+  var id: String
+  var version: String
+  var account: String
+  var time: String
+  var region: String
+  var resources: js.Array[String]
+  var source: String
+  var `detail-type`: TDetailType
+  var detail: TDetail
+}
+
+object EventBridgeEvent {
+  def apply[TDetailType <: String, TDetail](
+      id: String,
+      version: String,
+      account: String,
+      time: String,
+      region: String,
+      resources: js.Array[String],
+      source: String,
+      `detail-type`: TDetailType,
+      detail: TDetail
+  ): EventBridgeEvent[TDetailType, TDetail] = {
+    val _obj$ = js.Dynamic.literal(
+      "id" -> id.asInstanceOf[js.Any],
+      "version" -> version.asInstanceOf[js.Any],
+      "account" -> account.asInstanceOf[js.Any],
+      "time" -> time.asInstanceOf[js.Any],
+      "region" -> region.asInstanceOf[js.Any],
+      "resources" -> resources.asInstanceOf[js.Any],
+      "source" -> source.asInstanceOf[js.Any],
+      "detail-type" -> `detail-type`.asInstanceOf[js.Any],
+      "detail" -> detail.asInstanceOf[js.Any]
+    )
+    _obj$.asInstanceOf[EventBridgeEvent[TDetailType, TDetail]]
+  }
+}

--- a/src/main/scala/net/exoego/facade/aws_lambda/package.scala
+++ b/src/main/scala/net/exoego/facade/aws_lambda/package.scala
@@ -200,4 +200,10 @@ package object aws_lambda {
   type AsyncSQSHandler = AsyncHandler[SQSEvent, Unit]
   type SQSMessageAttributeDataType = String
   type SQSMessageAttributes = js.Dictionary[SQSMessageAttribute]
+
+  // eventbridge
+  type EventBridgeHandler[TDetailType <: String, TDetail, TResult] =
+    Handler[EventBridgeEvent[TDetailType, TDetail], TResult]
+  type AsyncEventBridgeHandler[TDetailType <: String, TDetail, TResult] =
+    AsyncHandler[EventBridgeEvent[TDetailType, TDetail], TResult]
 }


### PR DESCRIPTION
From this PR, the implementations leverages literal type added in Scala 2.13.
To cross-compile for Scala 2.12, some files are prepared for Scala 2.12 and 2.13.
