### PR TITLE
Fixes #183 Corrected CloudFrontRequestEvent and CloudFrontResponseEvent

### DIFF
--- a/src/main/scala/net/exoego/facade/aws_lambda/cloudfront_request.scala
+++ b/src/main/scala/net/exoego/facade/aws_lambda/cloudfront_request.scala
@@ -6,8 +6,14 @@ import scala.scalajs.js
 
 @Factory
 @js.native
-trait CloudFrontRequestEventRecordItem extends js.Object with CloudFrontEvent {
+trait CloudFrontRequestEventCf extends js.Object with CloudFrontEvent {
   var request: CloudFrontRequest = js.native
+}
+
+@Factory
+@js.native
+trait CloudFrontRequestEventRecordItem extends js.Object {
+  var cf: CloudFrontRequestEventCf = js.native
 }
 
 @Factory

--- a/src/main/scala/net/exoego/facade/aws_lambda/cloudfront_response.scala
+++ b/src/main/scala/net/exoego/facade/aws_lambda/cloudfront_response.scala
@@ -6,10 +6,16 @@ import scala.scalajs.js
 
 @Factory
 @js.native
-trait CloudFrontResponseEventRecordItem extends js.Object {
+trait CloudFrontResponseEventCf extends js.Object {
   var config: CloudFrontEvent.Config = js.native
   def request: CloudFrontRequest = js.native
   var response: CloudFrontResponse = js.native
+}
+
+@Factory
+@js.native
+trait CloudFrontResponseEventRecordItem extends js.Object {
+  var cf: CloudFrontResponseEventCf = js.native
 }
 
 @Factory


### PR DESCRIPTION
Hi!

I hope this PR is sufficiently done, if not please give critique and I'll fix it.

Example payload taken from the AWS CloudFrontRequestEvent test
```{
  "Records": [
    {
      "cf": {
        "config": {
          "distributionId": "EXAMPLE"
        },
        "request": {
          "headers": {
            "host": [
              {
                "key": "Host",
                "value": "d123.cf.net"
              }
            ],
            "user-name": [
              {
                "key": "User-Name",
                "value": "CloudFront"
              }
            ]
          },
          "clientIp": "2001:cdba::3257:9652",
          "uri": "/test",
          "method": "GET"
        },
        "response": {
          "status": "200",
          "statusDescription": "OK",
          "headers": {
            "x-cache": [
              {
                "key": "X-Cache",
                "value": "Hello from Cloudfront"
              }
            ]
          }
        }
      }
    }
  ]
}