### PR TITLE
Switch to scalajs-dynamodb-shared

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@ scalacOptions --= Seq(
   "-Ywarn-unused:params"
 )
 
-val awsSdkScalajsFacadeVersion = "0.33.0-v2.892.0"
 libraryDependencies ++= Seq(
-  "net.exoego" %%% "aws-sdk-scalajs-facade-dynamodb" % awsSdkScalajsFacadeVersion cross CrossVersion.for3Use2_13
+  "net.exoego" %%% "scalajs-dynamodb-shared" % "0.0.1"
 )

--- a/src/main/scala/net/exoego/facade/aws_lambda/package.scala
+++ b/src/main/scala/net/exoego/facade/aws_lambda/package.scala
@@ -115,7 +115,7 @@ package object aws_lambda {
   @inline val APIGatewayProxyEvent = APIGatewayProxyEventBase
 
   // dynamodb-stream
-  type AttributeValue = facade.amazonaws.services.dynamodb.AttributeValue
+  type AttributeValue = facade.amazonaws.services.dynamodb.shared.AttributeValue
   type DynamoDBStreamHandler = Handler[DynamoDBStreamEvent, Unit]
   type AsyncDynamoDBStreamHandler = AsyncHandler[DynamoDBStreamEvent, Unit]
 


### PR DESCRIPTION
This repo now depends on [scalajs-dynamodb-shared](https://github.com/exoego/scalajs-dynamodb-shared), which is spin-out from [aws-sdk-scalajs-facade](https://github.com/exoego/aws-sdk-scalajs-facade).
So one can use this library with `aws-sdk-v3-scalajs-facade` (future, maybe).


